### PR TITLE
read transport_maps from mysql table transports

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,8 @@
       mode: "u=rw,g=r,o=r"
     - name: smtpd_sender_login_maps.cf
       mode: "u=rw,g=,o="
+    - name: transport_maps.cf
+      mode: "u=rw,g=,o="
     - name: virtual_alias_maps.cf
       mode: "u=rw,g=,o="
     - name: virtual_mailbox_domains.cf

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -35,6 +35,7 @@ virtual_transport = lmtp:{{_postfix_config.lmtp_socket}}
 virtual_mailbox_domains = mysql:{{_postfix_config.config_dir}}/virtual_mailbox_domains.cf
 virtual_mailbox_maps = mysql:{{_postfix_config.config_dir}}/virtual_mailbox_maps.cf
 virtual_alias_maps = mysql:{{_postfix_config.config_dir}}/virtual_alias_maps.cf
+trasport_maps = proxy:mysql:{{_postfix_config.config_dir}}/transport_maps.cf
 
 recipient_delimiter = {{ _postfix_config.recipient_delimiter|default("") }}
 

--- a/templates/transport_maps.cf.j2
+++ b/templates/transport_maps.cf.j2
@@ -1,0 +1,5 @@
+user = {{ _postfix_mysql.user }}
+password = {{ _postfix_mysql.password }}
+hosts = {{ _postfix_mysql.host }}
+dbname = {{ _postfix_mysql.database }}
+query = SELECT transport FROM transport WHERE domain='%s'


### PR DESCRIPTION
Adopts the `transport` MySQL table to lookup domain specific transports.

The table was introduced in the database scheme with https://github.com/mailserver/ansible-role-mysql-seed/commit/6827a06b599eef0f2708ab00ecc48b40fda62ed0