### PR TITLE
Additional Transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Examples
         file: "/etc/ssl/postfix_dhparams.pem"
     daemon_user: "postfix"
     milter_group: "milter" 
+
     milters:
       submission:
         - name: opendkim
@@ -41,6 +42,17 @@ Examples
           socket: "milters/spamass.sock"
         - name: clamav
           socket: "milters/clamav-milter.ctl"
+
+    transports:
+      - name: mailman
+        unpriv: 'n'
+        chroot: 'n'
+        command: 'pipe'
+        args:
+          flags: 'FR'
+          user: 'list'
+          argv: /usr/lib/mailman/bin/postfix-to-mailman.py
+
   postfix_mysql:
     host: "127.0.0.1"
     port: 3306

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,9 @@ postfix_default_config:
     # Milters meant to process mail: Spamassassin, ClamAV, etc.
     incoming_smtpd: []
 
+  # Transports
+  transports: []
+
 # MySQL
 postfix_default_mysql:
   host: "127.0.0.1"

--- a/templates/master.cf.j2
+++ b/templates/master.cf.j2
@@ -31,6 +31,12 @@ unix:{{milter.socket}}{% if not loop.last %},{% endif %}
 {% endfor %}
   -o cleanup_service_name=subcleanup
 
+{% for transport in _postfix_config.transports %}
+{{transport.name}} {{transport.type | default('unix')}}  {{transport.private | default('-')}} {{transport.unpriv | default('-')}} {{transport.chroot | default('-')}} {{transport.wakeup | default('-')}} {{transport.maxproc | default('-')}} {{transport.command | default('-')}}
+  {% for (key, value) in (args | default([])) %}{{key}}={{value}}{% if not loop.last %} {% endif %}{% endfor %}
+  {{transport.nexthop | default('${nexthop}')}} {{transport.user | default('${user}')}}
+{% endfor %}
+
 # Postfix subsystems
 pickup          fifo    n       -       -       60      1       pickup
 cleanup         unix    n       -       -       -       0       cleanup


### PR DESCRIPTION
Allows to insert additional transports in master.cf via role options

Valid transport options are: 
- private 
- unpriv
- chroot
- wakeup
- maxproc
- command

### Example

```yaml
postfix_config:
  ...
  transports:
    - name: mailman
      unpriv: 'n'
      chroot: 'n'
      command: 'pipe'
      args:
        - 'flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py'
        - '${nexthop} ${user}'
...
```

would result in

```
mailman   unix  -       n       n       -       -       pipe
  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
  ${nexthop} ${user}
```